### PR TITLE
Do not add nonexistent jobs to job list

### DIFF
--- a/internal/slurm/v24xx/slurm.go
+++ b/internal/slurm/v24xx/slurm.go
@@ -455,6 +455,9 @@ func (api *slurmApi) QueryJobs(clusterName string, jobIds []int64) ([]slurm_comm
 
 	// Sanity check that we actually go what we requested.
 	for jobId, job := range jobQueries {
+		if job.sa == nil && job.sc == nil {
+			return nil, fmt.Errorf("Requested job (%s, %d) does not contain sa or sc data", clusterName, jobId)
+		}
 		if job == nil {
 			return nil, fmt.Errorf("Requested job (%s, %d) unavailable", clusterName, jobId)
 		}


### PR DESCRIPTION
Clustercockpit may contain jobs, which are not present in sacct db any more. This patch reports them and prevents cc-slurm-adapter from adding them to the job list.

Fixes issue #22 